### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ counting of visitors to this page in this section started from May 8, 2022
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=BEPb/BEPb&type=Date)](https://star-history.com/#BEPb/BEPb&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=BEPb/BEPb&type=Date)](https://star-history.dera.page/#BEPb/BEPb&Date)
 
 
 


### PR DESCRIPTION
The star history chart in the README is currently broken, so the image no longer renders. This change points the chart to a working provider that requires no API token, restoring the visual history of stargazers for this repository.